### PR TITLE
Respect rate limit, and fix warnings, etc.

### DIFF
--- a/bodegha.py
+++ b/bodegha.py
@@ -208,12 +208,12 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
             downloaded_prs = \
                 len(comments[lambda x: x['type'] == 'pullRequests'].drop_duplicates('number'))
 
-        if last_issue is None and issue_total > downloaded_issues:
+        if issue and last_issue is None and issue_total > downloaded_issues:
             issue = True
             beforeIssue = issue_end_cursor
         else:
             issue = False
-        if last_pr is None and pr_total > downloaded_prs:
+        if pr and last_pr is None and pr_total > downloaded_prs:
             pr = True
             beforePr = pr_end_cursor
         else:

--- a/bodegha.py
+++ b/bodegha.py
@@ -234,6 +234,7 @@ def download_comments(repository, apikey, pr=True, issue=True, beforePr=None, be
                 }
             ).encode('utf-8')
         )
+    req.add_header("User-Agent", "Mozilla/5.0")
     req.add_header("Accept", "application/json")
     req.add_header("Content-Type", "application/json")
     req.add_header("Authorization", "Bearer {}".format(apikey))

--- a/bodegha.py
+++ b/bodegha.py
@@ -201,7 +201,9 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
         # Wait for one hour if the number of queries is close to the limit, to make sure that the score gets reset.
         if queryCounter > 19:
             queryCounter = 0
+            tqdm.write("Wait for one hour, to prevent exceeding the rate limit of GitHub...")
             time.sleep(3700)
+            tqdm.write("Continue downloading...")
 
         try:
             data = download_comments(repository, apikey, pr, issue, beforePr, beforeIssue)
@@ -210,7 +212,9 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
             # an HTTP 502 error is raised. If so, wait an hour to make sure that the score is properly
             # reset in order to continue.
             if err.code == 502:
+                tqdm.write("Wait for one hour, to prevent exceeding the rate limit of GitHub...")
                 time.sleep(3700)
+                tqdm.write("Continue downloading...")
                 data = download_comments(repository, apikey, pr, issue, beforePr, beforeIssue)
             else:
                 raise


### PR DESCRIPTION
As GitHub has recently adjusted their rate limit for its GraphQL API (see https://docs.github.com/en/graphql/overview/resource-limitations), BoDeGHa runs into errors when the number of requests per hour exceeds the rate limit per hour. With this PR, I provide a fix in which BoDeGHa waits for more than one hour and retries sending the request afterwards. For more details, please see the commit message of the corresponding commit (04fd12ab0f1168f52e6b1455954596886995bdc8).

In addition, I fixed a few minor issues and pandas warnings that blow up the logs (i.e., deprecated `append` calls for DataFrames).