### PR TITLE
Removed rate limit per contributor

### DIFF
--- a/bodegha.py
+++ b/bodegha.py
@@ -192,19 +192,17 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
     issue = True
     beforePr = None
     beforeIssue = None
-    while True:
-
-        # To prevent exceeding the rate limit of the GitHub GraphQL API, make sure that the rate limit score
-        # for this script stays below GitHub's limit. For more details, see the following documentation:
-        # https://docs.github.com/en/graphql/overview/resource-limitations
-        # Wait for one hour if the number of queries is close to the limit, to make sure that the limit gets reset.
+    while issue or pr:
 
         try:
             data = download_comments(repository, apikey, pr, issue, beforePr, beforeIssue)
         except HTTPError as err:
             # If the rate limit score of the GitHub GraphQL API exceeds the rate limit,
-            # an HTTP 502 error is raised. If so, wait an hour to make sure that the score is properly
+            # an HTTP 502 error is raised.
+            # If so, wait an hour to make sure that the score is properly
             # reset in order to continue.
+            # For more details, see the following documentation:
+            # https://docs.github.com/en/graphql/overview/resource-limitations.
             if err.code == 502:
                 tqdm.write("Wait for one hour, to prevent exceeding the rate limit of GitHub...")
                 time.sleep(3700)
@@ -238,9 +236,6 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
             beforePr = pr_end_cursor
         else:
             pr = False
-
-        if not issue and not pr:
-            break
 
     return comments
 

--- a/bodegha.py
+++ b/bodegha.py
@@ -192,19 +192,12 @@ def process_comments(repository, accounts, date, min_comments, max_comments, api
     issue = True
     beforePr = None
     beforeIssue = None
-    queryCounter = 0
     while True:
-        queryCounter += 1
 
         # To prevent exceeding the rate limit of the GitHub GraphQL API, make sure that the rate limit score
         # for this script stays below GitHub's limit. For more details, see the following documentation:
         # https://docs.github.com/en/graphql/overview/resource-limitations
-        # Wait for one hour if the number of queries is close to the limit, to make sure that the score gets reset.
-        if queryCounter > 19:
-            queryCounter = 0
-            tqdm.write("Wait for one hour, to prevent exceeding the rate limit of GitHub...")
-            time.sleep(3700)
-            tqdm.write("Continue downloading...")
+        # Wait for one hour if the number of queries is close to the limit, to make sure that the limit gets reset.
 
         try:
             data = download_comments(repository, apikey, pr, issue, beforePr, beforeIssue)


### PR DESCRIPTION
Fixed some unnecessary code additions proposed in merged PR #21.
Removed query counter conditional code that was used to control the API rate limit per contributor. This code is not required at all since the try statement following it already covers the error code 502, so the API rate limit check will be handled correctly in any case.